### PR TITLE
feat: Support for native WP endpoints and moved dependencies from DB to a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+config.php
 .idea/
 wp/
 wp-content/

--- a/README.md
+++ b/README.md
@@ -17,25 +17,23 @@
 ## Features
 
 - Only includes the plugins you need for the endpoint
-- No code changes needed. Just install and activate this plugin
-- Full support with [WP-FastEndpoints](https://github.com/matapatos/wp-fastendpoints)
+- No code changes needed. Just install and activate this plugin as an MU plugin
+- Full support with both native WP REST endpoints or [WP-FastEndpoints](https://github.com/matapatos/wp-fastendpoints)
 
 ## Requirements
 
 - PHP 8.1+
 - WordPress 6.x
 - [composer/installers](https://packagist.org/packages/composer/installers)
+- Install as a [must-use plugin](https://developer.wordpress.org/advanced-administration/plugins/mu-plugins/)
 
 We aim to support versions that haven't reached their end-of-life.
 
 ## Installation
 
 1. Download plugin from WordPress store
-2. Activate plugin
-
-### Not using Bedrock?
-
-If not using [Bedrock](https://roots.io/bedrock/) make sure to install WP-FastEndpoints-Depends as a
-[must-use plugin](https://developer.wordpress.org/advanced-administration/plugins/mu-plugins/)
+2. Install plugin as a [MU-plugin](https://developer.wordpress.org/advanced-administration/plugins/mu-plugins/)
+3. Run the following WP CLI command `wp fastendpoints depends`
+4. Done! 😊
 
 FastEndpoints Depends was created by **[André Gil](https://www.linkedin.com/in/andre-gil/)** and is open-sourced software licensed under the **[MIT license](https://opensource.org/licenses/MIT)**.

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "matapatos/wp-fastendpoints-depends",
+  "name": "matapatos/fastendpoints-depends",
   "type": "wordpress-muplugin",
   "description": "Speed up your REST endpoints by using plugins as dependencies",
   "keywords": [
@@ -13,7 +13,7 @@
   "require": {
     "php": "^8.1",
     "composer/installers": "^2.2",
-    "matapatos/wp-fastendpoints-contracts": "^0.9.0"
+    "matapatos/wp-fastendpoints-contracts": "^1.1"
   },
   "autoload": {
     "psr-4": {
@@ -34,7 +34,7 @@
     "brain/monkey": "2.*",
     "laravel/pint": "*",
     "pestphp/pest-plugin-parallel": "^1.2",
-    "matapatos/wp-fastendpoints": "^2.0"
+    "matapatos/wp-fastendpoints": "^2.1"
   },
   "scripts": {
     "lint": "./vendor/bin/pint --config pint.json",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "78ac5a62031248f7d4c1c49b26dd9cee",
+    "content-hash": "5293c1fc114475cd0a9ce4155e3b8b9f",
     "packages": [
         {
             "name": "composer/installers",
@@ -154,16 +154,16 @@
         },
         {
             "name": "matapatos/wp-fastendpoints-contracts",
-            "version": "v0.9.0",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/matapatos/wp-fastendpoints-contracts.git",
-                "reference": "f5ded0779f955ca7a87816bfdfe0c57faf382568"
+                "reference": "633568a2fd9ae6946b47628824cb302d6b85d85b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matapatos/wp-fastendpoints-contracts/zipball/f5ded0779f955ca7a87816bfdfe0c57faf382568",
-                "reference": "f5ded0779f955ca7a87816bfdfe0c57faf382568",
+                "url": "https://api.github.com/repos/matapatos/wp-fastendpoints-contracts/zipball/633568a2fd9ae6946b47628824cb302d6b85d85b",
+                "reference": "633568a2fd9ae6946b47628824cb302d6b85d85b",
                 "shasum": ""
             },
             "require": {
@@ -190,9 +190,9 @@
             ],
             "support": {
                 "issues": "https://github.com/matapatos/wp-fastendpoints-contracts/issues",
-                "source": "https://github.com/matapatos/wp-fastendpoints-contracts/tree/v0.9.0"
+                "source": "https://github.com/matapatos/wp-fastendpoints-contracts/tree/v1.1.0"
             },
-            "time": "2024-09-17T07:58:01+00:00"
+            "time": "2024-11-15T14:16:26+00:00"
         }
     ],
     "packages-dev": [
@@ -248,20 +248,20 @@
         },
         {
             "name": "antecedent/patchwork",
-            "version": "2.1.28",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/antecedent/patchwork.git",
-                "reference": "6b30aff81ebadf0f2feb9268d3e08385cebcc08d"
+                "reference": "b07d4fb37c3c723c8755122160c089e077d5de65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/6b30aff81ebadf0f2feb9268d3e08385cebcc08d",
-                "reference": "6b30aff81ebadf0f2feb9268d3e08385cebcc08d",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/b07d4fb37c3c723c8755122160c089e077d5de65",
+                "reference": "b07d4fb37c3c723c8755122160c089e077d5de65",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "php": ">=7.1.0"
             },
             "require-dev": {
                 "phpunit/phpunit": ">=4"
@@ -290,22 +290,22 @@
             ],
             "support": {
                 "issues": "https://github.com/antecedent/patchwork/issues",
-                "source": "https://github.com/antecedent/patchwork/tree/2.1.28"
+                "source": "https://github.com/antecedent/patchwork/tree/2.2.0"
             },
-            "time": "2024-02-06T09:26:11+00:00"
+            "time": "2024-09-27T16:59:55+00:00"
         },
         {
             "name": "brain/monkey",
-            "version": "2.6.1",
+            "version": "2.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Brain-WP/BrainMonkey.git",
-                "reference": "a31c84515bb0d49be9310f52ef1733980ea8ffbb"
+                "reference": "d95a9d895352c30f47604ad1b825ab8fa9d1a373"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/a31c84515bb0d49be9310f52ef1733980ea8ffbb",
-                "reference": "a31c84515bb0d49be9310f52ef1733980ea8ffbb",
+                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/d95a9d895352c30f47604ad1b825ab8fa9d1a373",
+                "reference": "d95a9d895352c30f47604ad1b825ab8fa9d1a373",
                 "shasum": ""
             },
             "require": {
@@ -322,7 +322,7 @@
             "extra": {
                 "branch-alias": {
                     "dev-version/1": "1.x-dev",
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "2.x-dev"
                 }
             },
             "autoload": {
@@ -362,7 +362,7 @@
                 "issues": "https://github.com/Brain-WP/BrainMonkey/issues",
                 "source": "https://github.com/Brain-WP/BrainMonkey"
             },
-            "time": "2021-11-11T15:53:55+00:00"
+            "time": "2024-08-29T20:15:04+00:00"
         },
         {
             "name": "brianium/paratest",
@@ -657,26 +657,26 @@
         },
         {
             "name": "filp/whoops",
-            "version": "2.15.4",
+            "version": "2.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "a139776fa3f5985a50b509f2a02ff0f709d2a546"
+                "reference": "befcdc0e5dce67252aa6322d82424be928214fa2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/a139776fa3f5985a50b509f2a02ff0f709d2a546",
-                "reference": "a139776fa3f5985a50b509f2a02ff0f709d2a546",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/befcdc0e5dce67252aa6322d82424be928214fa2",
+                "reference": "befcdc0e5dce67252aa6322d82424be928214fa2",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9 || ^7.0 || ^8.0",
+                "php": "^7.1 || ^8.0",
                 "psr/log": "^1.0.1 || ^2.0 || ^3.0"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9 || ^1.0",
-                "phpunit/phpunit": "^4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.8 || ^9.3.3",
-                "symfony/var-dumper": "^2.6 || ^3.0 || ^4.0 || ^5.0"
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.8 || ^9.3.3",
+                "symfony/var-dumper": "^4.0 || ^5.0"
             },
             "suggest": {
                 "symfony/var-dumper": "Pretty print complex values better with var-dumper available",
@@ -716,7 +716,7 @@
             ],
             "support": {
                 "issues": "https://github.com/filp/whoops/issues",
-                "source": "https://github.com/filp/whoops/tree/2.15.4"
+                "source": "https://github.com/filp/whoops/tree/2.16.0"
             },
             "funding": [
                 {
@@ -724,7 +724,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-11-03T12:00:00+00:00"
+            "time": "2024-09-25T12:00:00+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -854,16 +854,16 @@
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "6ea8dd08867a2a42619d65c3deb2c0fcbf81c8f8"
+                "reference": "f9c436286ab2892c7db7be8c8da4ef61ccf7b455"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/6ea8dd08867a2a42619d65c3deb2c0fcbf81c8f8",
-                "reference": "6ea8dd08867a2a42619d65c3deb2c0fcbf81c8f8",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/f9c436286ab2892c7db7be8c8da4ef61ccf7b455",
+                "reference": "f9c436286ab2892c7db7be8c8da4ef61ccf7b455",
                 "shasum": ""
             },
             "require": {
@@ -917,7 +917,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.0.3"
+                "source": "https://github.com/guzzle/promises/tree/2.0.4"
             },
             "funding": [
                 {
@@ -933,7 +933,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-18T10:29:17+00:00"
+            "time": "2024-10-17T10:06:22+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -1104,28 +1104,28 @@
         },
         {
             "name": "jean85/pretty-package-versions",
-            "version": "2.0.6",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Jean85/pretty-package-versions.git",
-                "reference": "f9fdd29ad8e6d024f52678b570e5593759b550b4"
+                "reference": "3c4e5f62ba8d7de1734312e4fff32f67a8daaf10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Jean85/pretty-package-versions/zipball/f9fdd29ad8e6d024f52678b570e5593759b550b4",
-                "reference": "f9fdd29ad8e6d024f52678b570e5593759b550b4",
+                "url": "https://api.github.com/repos/Jean85/pretty-package-versions/zipball/3c4e5f62ba8d7de1734312e4fff32f67a8daaf10",
+                "reference": "3c4e5f62ba8d7de1734312e4fff32f67a8daaf10",
                 "shasum": ""
             },
             "require": {
-                "composer-runtime-api": "^2.0.0",
-                "php": "^7.1|^8.0"
+                "composer-runtime-api": "^2.1.0",
+                "php": "^7.4|^8.0"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^3.2",
                 "jean85/composer-provided-replaced-stub-package": "^1.0",
                 "phpstan/phpstan": "^1.4",
-                "phpunit/phpunit": "^7.5|^8.5|^9.4",
-                "vimeo/psalm": "^4.3"
+                "phpunit/phpunit": "^7.5|^8.5|^9.6",
+                "vimeo/psalm": "^4.3 || ^5.0"
             },
             "type": "library",
             "extra": {
@@ -1157,22 +1157,22 @@
             ],
             "support": {
                 "issues": "https://github.com/Jean85/pretty-package-versions/issues",
-                "source": "https://github.com/Jean85/pretty-package-versions/tree/2.0.6"
+                "source": "https://github.com/Jean85/pretty-package-versions/tree/2.1.0"
             },
-            "time": "2024-03-08T09:58:59+00:00"
+            "time": "2024-11-18T16:19:46+00:00"
         },
         {
             "name": "laravel/pint",
-            "version": "v1.17.3",
+            "version": "v1.18.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "9d77be916e145864f10788bb94531d03e1f7b482"
+                "reference": "35c00c05ec43e6b46d295efc0f4386ceb30d50d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/9d77be916e145864f10788bb94531d03e1f7b482",
-                "reference": "9d77be916e145864f10788bb94531d03e1f7b482",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/35c00c05ec43e6b46d295efc0f4386ceb30d50d9",
+                "reference": "35c00c05ec43e6b46d295efc0f4386ceb30d50d9",
                 "shasum": ""
             },
             "require": {
@@ -1225,24 +1225,25 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2024-09-03T15:00:28+00:00"
+            "time": "2024-09-24T17:22:50+00:00"
         },
         {
             "name": "matapatos/wp-fastendpoints",
-            "version": "v2.0.0",
+            "version": "v2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/matapatos/wp-fastendpoints.git",
-                "reference": "914d55ba3e124807a36708ad79526c5ea721b874"
+                "reference": "eb5d9be31224cbd75560a660220d0d04b7c3cf0b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matapatos/wp-fastendpoints/zipball/914d55ba3e124807a36708ad79526c5ea721b874",
-                "reference": "914d55ba3e124807a36708ad79526c5ea721b874",
+                "url": "https://api.github.com/repos/matapatos/wp-fastendpoints/zipball/eb5d9be31224cbd75560a660220d0d04b7c3cf0b",
+                "reference": "eb5d9be31224cbd75560a660220d0d04b7c3cf0b",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
+                "matapatos/wp-fastendpoints-contracts": "^1.1",
                 "opis/json-schema": "^2.3",
                 "php": "^8.1",
                 "php-di/invoker": "^2.3"
@@ -1252,6 +1253,7 @@
                 "dingo-d/wp-pest": "^1.6",
                 "laravel/pint": "*",
                 "mockery/mockery": "^1.6",
+                "pestphp/pest-plugin-parallel": "^1.2",
                 "roots/acorn": "^4.2"
             },
             "type": "library",
@@ -1272,9 +1274,9 @@
             ],
             "support": {
                 "issues": "https://github.com/matapatos/wp-fastendpoints/issues",
-                "source": "https://github.com/matapatos/wp-fastendpoints/tree/v2.0.0"
+                "source": "https://github.com/matapatos/wp-fastendpoints/tree/v2.1.0"
             },
-            "time": "2024-07-17T07:57:01+00:00"
+            "time": "2024-11-15T14:49:59+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -1361,16 +1363,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.12.0",
+            "version": "1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c"
+                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
-                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/123267b2c49fbf30d78a7b2d333f6be754b94845",
+                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845",
                 "shasum": ""
             },
             "require": {
@@ -1409,7 +1411,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.1"
             },
             "funding": [
                 {
@@ -1417,20 +1419,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-12T14:39:25+00:00"
+            "time": "2024-11-08T17:47:46+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.2.0",
+            "version": "v5.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "23c79fbbfb725fb92af9bcf41065c8e9a0d49ddb"
+                "reference": "8eea230464783aa9671db8eea6f8c6ac5285794b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/23c79fbbfb725fb92af9bcf41065c8e9a0d49ddb",
-                "reference": "23c79fbbfb725fb92af9bcf41065c8e9a0d49ddb",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/8eea230464783aa9671db8eea6f8c6ac5285794b",
+                "reference": "8eea230464783aa9671db8eea6f8c6ac5285794b",
                 "shasum": ""
             },
             "require": {
@@ -1473,9 +1475,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.2.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.3.1"
             },
-            "time": "2024-09-15T16:40:33+00:00"
+            "time": "2024-10-08T18:51:32+00:00"
         },
         {
             "name": "nunomaduro/collision",
@@ -3887,16 +3889,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.12",
+            "version": "v6.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "72d080eb9edf80e36c19be61f72c98ed8273b765"
+                "reference": "f1fc6f47283e27336e7cebb9e8946c8de7bff9bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/72d080eb9edf80e36c19be61f72c98ed8273b765",
-                "reference": "72d080eb9edf80e36c19be61f72c98ed8273b765",
+                "url": "https://api.github.com/repos/symfony/console/zipball/f1fc6f47283e27336e7cebb9e8946c8de7bff9bd",
+                "reference": "f1fc6f47283e27336e7cebb9e8946c8de7bff9bd",
                 "shasum": ""
             },
             "require": {
@@ -3961,7 +3963,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.12"
+                "source": "https://github.com/symfony/console/tree/v6.4.15"
             },
             "funding": [
                 {
@@ -3977,7 +3979,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-20T08:15:52+00:00"
+            "time": "2024-11-06T14:19:14+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -4048,16 +4050,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.4.44",
+            "version": "v5.4.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "76c3818964e9d32be3862c9318ae3ba9aa280ddc"
+                "reference": "57c8294ed37d4a055b77057827c67f9558c95c54"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/76c3818964e9d32be3862c9318ae3ba9aa280ddc",
-                "reference": "76c3818964e9d32be3862c9318ae3ba9aa280ddc",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/57c8294ed37d4a055b77057827c67f9558c95c54",
+                "reference": "57c8294ed37d4a055b77057827c67f9558c95c54",
                 "shasum": ""
             },
             "require": {
@@ -4095,7 +4097,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.4.44"
+                "source": "https://github.com/symfony/filesystem/tree/v5.4.45"
             },
             "funding": [
                 {
@@ -4111,7 +4113,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-16T14:52:48+00:00"
+            "time": "2024-10-22T13:05:35+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4513,16 +4515,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v6.4.12",
+            "version": "v6.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "3f94e5f13ff58df371a7ead461b6e8068900fbb3"
+                "reference": "3cb242f059c14ae08591c5c4087d1fe443564392"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/3f94e5f13ff58df371a7ead461b6e8068900fbb3",
-                "reference": "3f94e5f13ff58df371a7ead461b6e8068900fbb3",
+                "url": "https://api.github.com/repos/symfony/process/zipball/3cb242f059c14ae08591c5c4087d1fe443564392",
+                "reference": "3cb242f059c14ae08591c5c4087d1fe443564392",
                 "shasum": ""
             },
             "require": {
@@ -4554,7 +4556,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.4.12"
+                "source": "https://github.com/symfony/process/tree/v6.4.15"
             },
             "funding": [
                 {
@@ -4570,7 +4572,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-17T12:47:12+00:00"
+            "time": "2024-11-06T14:19:14+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -4657,16 +4659,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.12",
+            "version": "v6.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "f8a1ccebd0997e16112dfecfd74220b78e5b284b"
+                "reference": "73a5e66ea2e1677c98d4449177c5a9cf9d8b4c6f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/f8a1ccebd0997e16112dfecfd74220b78e5b284b",
-                "reference": "f8a1ccebd0997e16112dfecfd74220b78e5b284b",
+                "url": "https://api.github.com/repos/symfony/string/zipball/73a5e66ea2e1677c98d4449177c5a9cf9d8b4c6f",
+                "reference": "73a5e66ea2e1677c98d4449177c5a9cf9d8b4c6f",
                 "shasum": ""
             },
             "require": {
@@ -4723,7 +4725,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.12"
+                "source": "https://github.com/symfony/string/tree/v6.4.15"
             },
             "funding": [
                 {
@@ -4739,7 +4741,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-20T08:15:52+00:00"
+            "time": "2024-11-13T13:31:12+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/fastendpoints-depends.php
+++ b/fastendpoints-depends.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Plugin Name: Fast Endpoints Depends
+ * Plugin Name: FastEndpoints Depends
  * Plugin URI:  https://github.com/matapatos/wp-fastendponts-depends
  * Description: Speed up your REST endpoints by treating plugins as dependencies
  * Version:     1.0.0
@@ -27,5 +27,5 @@ require_once $composer;
 $autoloader = $autoloader ?? new \Wp\FastEndpoints\Depends\DependsAutoloader;
 $autoloader->register();
 
-$dependencies = $generator ?? new \Wp\FastEndpoints\Depends\FastEndpointDependenciesGenerator;
+$dependencies = $generator ?? new \Wp\FastEndpoints\Depends\DependenciesGenerator;
 $dependencies->register(__FILE__);

--- a/pint.json
+++ b/pint.json
@@ -1,5 +1,5 @@
 {
   "exclude": [
-    "wp", "wp-content"
+    "wp", "wp-content", "tests/Data"
   ]
 }

--- a/src/DependenciesGenerator.php
+++ b/src/DependenciesGenerator.php
@@ -12,7 +12,7 @@ use WP_CLI;
  *
  * @link https://github.com/matapatos/wp-fastendponts-depends
  */
-class FastEndpointDependenciesGenerator
+class DependenciesGenerator
 {
     /**
      * Holds all registered FastEndpoints router

--- a/src/DependsCommand.php
+++ b/src/DependsCommand.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Wp\FastEndpoints\Depends;
+
+use WP_CLI;
+
+/**
+ * Manages REST endpoint dependencies
+ *
+ * @author André Gil <andre_gil22@hotmail.com>
+ *
+ * @link https://github.com/matapatos/wp-fastendponts-depends
+ */
+class DependsCommand
+{
+    private DependenciesGenerator $generator;
+
+    public function __construct(?DependenciesGenerator $generator = null)
+    {
+        $this->generator = $generator ?: new DependenciesGenerator;
+    }
+
+    /**
+     * Generates the REST dependencies needed for each endpoint
+     */
+    public function depends(): void
+    {
+        $this->generator->update();
+    }
+
+    /**
+     * Clears the REST dependencies
+     *
+     * @subcommand depends-clear
+     */
+    public function _clear(): void
+    {
+        $configFilePath = $this->generator->getConfigFilePath();
+        if (file_exists($configFilePath)) {
+            unlink($configFilePath);
+        }
+
+        WP_CLI::success('REST route dependencies cleared');
+    }
+}

--- a/tests/Data/config.php
+++ b/tests/Data/config.php
@@ -1,0 +1,26 @@
+<?php # Generated 2024-11-19T16:47:06+00:00
+return array (
+    'POST' =>
+        array(
+            '/my-plugin/v1/blog-post' =>
+                array (
+                    0 => 'my-plugin/my-plugin.php',
+                ),
+            '/my-plugin/v1/no-depends' => array(),
+        ),
+    'GET' =>
+        array (
+            '/my-plugin/v1/user' =>
+                array (
+                    0 => 'my-plugin/my-plugin.php',
+                    1 => 'buddypress/buddypress.php',
+                ),
+        ),
+    'DELETE' =>
+        array (
+            '/my-plugin/v1/blog-post/(?P<ID>[\\d]+)' =>
+                array (
+                    0 => 'my-plugin/my-plugin.php',
+                ),
+        ),
+);

--- a/tests/Data/empty-config.php
+++ b/tests/Data/empty-config.php
@@ -1,0 +1,4 @@
+<?php
+
+// Generated 2024-11-19T12:00:09+00:00
+return array();

--- a/tests/Helpers/Helpers.php
+++ b/tests/Helpers/Helpers.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Wp\FastEndpoints\Depends\Tests\Helpers;
 
+use Wp\FastEndpoints\Router;
+
 class Helpers
 {
     /**
@@ -69,5 +71,19 @@ class Helpers
     public static function isIntegrationTest(): bool
     {
         return isset($GLOBALS['argv']) && in_array('--group=integration', $GLOBALS['argv'], true);
+    }
+
+    /**
+     * Retrieves a router from a file
+     *
+     * @param  string  $filename  The router filename to be included
+     */
+    public static function getRouter(string $filename): Router
+    {
+        if (! str_ends_with($filename, '.php')) {
+            $filename = $filename.'.php';
+        }
+
+        return require \ROUTERS_DIR.$filename;
     }
 }

--- a/tests/Integration/DependenciesGeneratorTest.php
+++ b/tests/Integration/DependenciesGeneratorTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Holds integration tests for the DependenciesGenerator
+ *
+ * @since 1.0.0
+ *
+ * @license MIT
+ */
+
+declare(strict_types=1);
+
+namespace Wp\FastEndpoints\Depends\Tests\Integration;
+
+use Wp\FastEndpoints\Depends\Tests\Helpers\Helpers;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+if (! Helpers::isIntegrationTest()) {
+    return;
+}
+
+/*
+ * We need to provide the base test class to every integration test.
+ * This will enable us to use all the WordPress test goodies, such as
+ * factories and proper test cleanup.
+ */
+uses(TestCase::class);
+
+beforeEach(function () {
+    parent::setUp();
+});
+
+afterEach(function () {
+    parent::tearDown();
+    delete_option('fastendpoints_dependencies');
+    delete_option('active_plugins');
+    unset($_SERVER['REQUEST_URI']);
+    unset($_SERVER['REQUEST_METHOD']);
+});
+
+test('Retrieves correct route dependencies', function () {
+    $routeDependencies = [
+        'GET' => [
+            '/custom/route' => ['custom-route', 'get', 'plugin-not-active'],
+            '/fake-route' => [],
+        ],
+        'POST' => [
+            '/custom/route' => ['custom-route', 'post'],
+        ],
+    ];
+    update_option('fastendpoints_dependencies', $routeDependencies);
+    update_option('active_plugins', ['my-plugin', 'custom-route', 'get']);
+    $_SERVER['REQUEST_URI'] = '/custom/route';
+    $_SERVER['REQUEST_METHOD'] = 'GET';
+    expect(get_option('active_plugins'))
+        ->toEqual(['custom-route', 'get']);
+})->group('autoloader');
+
+test('No request method. Retrieves plugins all active plugins', function () {
+    $routeDependencies = [
+        'POST' => [
+            '/custom/route' => ['custom-route', 'post'],
+        ],
+    ];
+    update_option('fastendpoints_dependencies', $routeDependencies);
+    update_option('active_plugins', ['my-plugin', 'custom-route', 'put']);
+    $_SERVER['REQUEST_URI'] = '/custom/route';
+    $_SERVER['REQUEST_METHOD'] = 'PUT';
+    expect(get_option('active_plugins'))
+        ->toEqual(['my-plugin', 'custom-route', 'put']);
+})->group('autoloader');
+
+test('No route dependencies. Retrieves plugins all active plugins', function () {
+    $routeDependencies = [
+        'GET' => [
+            '/custom/route' => ['custom-route', 'get', 'plugin-not-active'],
+            '/fake-route' => [],
+        ],
+        'POST' => [
+            '/custom/route' => ['custom-route', 'post'],
+        ],
+    ];
+    update_option('fastendpoints_dependencies', $routeDependencies);
+    update_option('active_plugins', ['active-plugin']);
+    $_SERVER['REQUEST_URI'] = '/unknown/route';
+    $_SERVER['REQUEST_METHOD'] = 'GET';
+    expect(get_option('active_plugins'))
+        ->toEqual(['active-plugin']);
+})->group('autoloader');
+
+test('Regex route. Retrieves correct dependencies', function () {
+    $routeDependencies = [
+        'GET' => [
+            '/custom/route/(?P<ID>[\d]+)' => ['custom-route', 'get', 'plugin-not-active'],
+        ],
+    ];
+    update_option('fastendpoints_dependencies', $routeDependencies);
+    update_option('active_plugins', ['custom-route', 'get']);
+    $_SERVER['REQUEST_URI'] = '/custom/route/10';
+    $_SERVER['REQUEST_METHOD'] = 'GET';
+    expect(get_option('active_plugins'))
+        ->toEqual(['custom-route', 'get']);
+})->group('autoloader');

--- a/tests/Integration/Routers/FastEndpointsRouter.php
+++ b/tests/Integration/Routers/FastEndpointsRouter.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Holds an example of FastEndpoints router
+ *
+ * @since 1.0.0
+ *
+ * @license MIT
+ */
+
+declare(strict_types=1);
+
+use Wp\FastEndpoints\Router;
+
+$router = new Router('fast-endpoints', 'v1');
+$router->depends(['my-plugin']);
+
+$router->get('(?P<ID>[\d]+)', function () {
+    return 'Only requires my-plugin';
+});
+
+$router->post('(?P<ID>[\d]+)', function () {
+    return 'Requires both my-plugin and buddypress';
+})
+    ->depends(['buddypress']);
+
+return $router;

--- a/tests/Integration/Routers/NativeWpEndpoints.php
+++ b/tests/Integration/Routers/NativeWpEndpoints.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Holds an example of FastEndpoints router
+ *
+ * @since 1.0.0
+ *
+ * @license MIT
+ */
+
+declare(strict_types=1);
+
+add_action('rest_api_init', function () {
+    register_rest_route('native/v1', 'custom', [
+        'methods' => 'GET',
+        'callback' => function () {
+            return 'Only requires my-plugin';
+        },
+        'depends' => ['my-plugin'],
+        'permission_callback' => '__return_true',
+    ]);
+
+    register_rest_route('native/v1', 'custom', [
+        'methods' => 'POST',
+        'callback' => function () {
+            return 'Requires both my-plugin and buddypress';
+        },
+        'depends' => ['my-plugin', 'buddypress'],
+        'permission_callback' => '__return_true',
+    ]);
+});

--- a/tests/Unit/DependenciesGeneratorTest.php
+++ b/tests/Unit/DependenciesGeneratorTest.php
@@ -17,7 +17,7 @@ use Brain\Monkey\Actions;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 use Mockery;
-use Wp\FastEndpoints\Depends\FastEndpointDependenciesGenerator;
+use Wp\FastEndpoints\Depends\DependenciesGenerator;
 use Wp\FastEndpoints\Depends\Tests\Helpers\Helpers;
 use Wp\FastEndpoints\Router;
 
@@ -32,7 +32,7 @@ afterEach(function () {
 // register
 
 test('Register generator', function () {
-    $generator = new FastEndpointDependenciesGenerator;
+    $generator = new DependenciesGenerator;
     Functions\expect('register_activation_hook')
         ->once()
         ->with('/test/example.php', \Mockery::type('closure'));
@@ -40,7 +40,7 @@ test('Register generator', function () {
 })->group('generator', 'register');
 
 test('Register generator via CLI', function () {
-    $generator = Mockery::mock(FastEndpointDependenciesGenerator::class)
+    $generator = Mockery::mock(DependenciesGenerator::class)
         ->makePartial()
         ->shouldAllowMockingProtectedMethods()
         ->shouldReceive('isRunningCli')
@@ -59,7 +59,7 @@ test('Register generator via CLI', function () {
 // update
 
 test('Add hooks to update dependencies', function () {
-    $generator = new FastEndpointDependenciesGenerator;
+    $generator = new DependenciesGenerator;
     $generator->update();
     Actions\has('fastendpoints_after_register', $generator->routerRegistered(...));
     Filters\has('wp_loaded', $generator->updateDependenciesOption(...));
@@ -70,7 +70,7 @@ test('Add hooks to update dependencies', function () {
 // routerRegistered
 
 test('Registering FastEndpoints routers', function (int $numRouters) {
-    $generator = new FastEndpointDependenciesGenerator;
+    $generator = new DependenciesGenerator;
     $allRegisteredRouters = Helpers::getNonPublicClassProperty($generator, 'allRegisteredRouters');
     expect($allRegisteredRouters)
         ->toBeArray()
@@ -93,7 +93,7 @@ test('Registering FastEndpoints routers via CLI', function (int $numRouters) {
         ->times($numRouters)
         ->with('Detected router with 2 endpoints');
 
-    $generator = Mockery::mock(FastEndpointDependenciesGenerator::class)
+    $generator = Mockery::mock(DependenciesGenerator::class)
         ->makePartial()
         ->shouldAllowMockingProtectedMethods()
         ->shouldReceive('isRunningCli')
@@ -143,7 +143,7 @@ test('Updates dependencies option', function () {
             'POST' => ['/my-plugin' => ['/wp/plugins/buddypress/plugin.php', '/wp/plugins/my-plugin/plugin.php']],
         ]);
 
-    $generator = Mockery::mock(FastEndpointDependenciesGenerator::class)
+    $generator = Mockery::mock(DependenciesGenerator::class)
         ->makePartial()
         ->shouldAllowMockingProtectedMethods()
         ->shouldReceive('getDependenciesFromRouters')
@@ -187,7 +187,7 @@ test('Updates dependencies option via CLI', function () {
             'POST' => ['/my-plugin' => ['/wp/plugins/buddypress/plugin.php', '/wp/plugins/my-plugin/plugin.php']],
         ]);
 
-    $generator = Mockery::mock(FastEndpointDependenciesGenerator::class)
+    $generator = Mockery::mock(DependenciesGenerator::class)
         ->makePartial()
         ->shouldAllowMockingProtectedMethods()
         ->shouldReceive('getDependenciesFromRouters')
@@ -207,7 +207,7 @@ test('Updates dependencies option via CLI', function () {
 
 test('Retrieving dependencies from routers', function () {
     Functions\expect('register_rest_route');
-    $generator = new FastEndpointDependenciesGenerator;
+    $generator = new DependenciesGenerator;
     $firstRouter = new Router('api', 'v1');
     $firstRouter->get('/first', function () {
         return true;

--- a/tests/Unit/DependenciesGeneratorTest.php
+++ b/tests/Unit/DependenciesGeneratorTest.php
@@ -14,12 +14,11 @@ namespace Wp\FastEndpoints\Depends\Tests\Unit;
 
 use Brain\Monkey;
 use Brain\Monkey\Actions;
-use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 use Mockery;
 use Wp\FastEndpoints\Depends\DependenciesGenerator;
+use Wp\FastEndpoints\Depends\DependsCommand;
 use Wp\FastEndpoints\Depends\Tests\Helpers\Helpers;
-use Wp\FastEndpoints\Router;
 
 beforeEach(function () {
     Monkey\setUp();
@@ -52,7 +51,7 @@ test('Register generator via CLI', function () {
     Mockery::mock('alias:WP_CLI')
         ->shouldReceive('add_command')
         ->once()
-        ->with('fast_endpoints_depends_update', Mockery::type('closure'));
+        ->with('fastendpoints', DependsCommand::class);
     $generator->register('/test/example.php');
 })->group('generator', 'register');
 
@@ -61,74 +60,35 @@ test('Register generator via CLI', function () {
 test('Add hooks to update dependencies', function () {
     $generator = new DependenciesGenerator;
     $generator->update();
-    Actions\has('fastendpoints_after_register', $generator->routerRegistered(...));
-    Filters\has('wp_loaded', $generator->updateDependenciesOption(...));
-    // Avoid no assertions warning
-    $this->assertTrue(true);
+    expect(Actions\has('wp_loaded', $generator->updateDependenciesConfig(...)))
+        ->toBe(10);
 })->group('generator', 'update');
 
-// routerRegistered
-
-test('Registering FastEndpoints routers', function (int $numRouters) {
-    $generator = new DependenciesGenerator;
-    $allRegisteredRouters = Helpers::getNonPublicClassProperty($generator, 'allRegisteredRouters');
-    expect($allRegisteredRouters)
-        ->toBeArray()
-        ->toBeEmpty();
-    $registeredRouters = [];
-    for ($i = 0; $i < $numRouters; $i++) {
-        $router = Mockery::mock('alias:Wp\FastEndpoints\Contracts\Http\Router');
-        $generator->routerRegistered($router);
-        $registeredRouters[] = $router;
-    }
-    $allRegisteredRouters = Helpers::getNonPublicClassProperty($generator, 'allRegisteredRouters');
-    expect($allRegisteredRouters)
-        ->toHaveCount($numRouters)
-        ->toMatchArray($registeredRouters);
-})->group('generator', 'routerRegistered')->with([1, 5]);
-
-test('Registering FastEndpoints routers via CLI', function (int $numRouters) {
-    Mockery::mock('alias:WP_CLI')
-        ->shouldReceive('debug')
-        ->times($numRouters)
-        ->with('Detected router with 2 endpoints');
+test('Update dependencies when WordPress is already loaded', function () {
+    Functions\expect('did_action')
+        ->once()
+        ->with('wp_loaded')
+        ->andReturn(true);
 
     $generator = Mockery::mock(DependenciesGenerator::class)
         ->makePartial()
-        ->shouldAllowMockingProtectedMethods()
-        ->shouldReceive('isRunningCli')
-        ->andReturn(true)
+        ->shouldReceive('updateDependenciesConfig')
+        ->once()
         ->getMock();
+    $generator->update();
+    expect(Actions\has('wp_loaded', $generator->updateDependenciesConfig(...)))
+        ->toBeFalsy();
+})->group('generator', 'update');
 
-    $allRegisteredRouters = Helpers::getNonPublicClassProperty($generator, 'allRegisteredRouters');
-    expect($allRegisteredRouters)
-        ->toBeArray()
-        ->toBeEmpty();
-    $registeredRouters = [];
-    for ($i = 0; $i < $numRouters; $i++) {
-        $router = Mockery::mock('alias:Wp\FastEndpoints\Contracts\Http\Router')
-            ->shouldReceive('getEndpoints')
-            ->andReturn([1, 2])
-            ->getMock();
+// getDependenciesPluginFullPath
 
-        $generator->routerRegistered($router);
-        $registeredRouters[] = $router;
-    }
-    $allRegisteredRouters = Helpers::getNonPublicClassProperty($generator, 'allRegisteredRouters');
-    expect($allRegisteredRouters)
-        ->toHaveCount($numRouters)
-        ->toMatchArray($registeredRouters);
-})->group('generator', 'routerRegistered')->with([1, 5]);
+test('Retrieve plugins full path from slug', function (bool $isRunningCli) {
+    Mockery::mock('alias:WP_CLI')
+        ->shouldReceive('debug')
+        ->times($isRunningCli ? 1 : 0)
+        ->with('[GET] /test updating dependency from seo to /wp/plugins/seo/plugin.php');
 
-// updateDependenciesOption
-
-test('Updates dependencies option', function () {
-    Functions\expect('path_join')
-        ->andReturnUsing(function ($val1, $val2) {
-            return "$val1/$val2";
-        });
-
-    Functions\expect('wp_get_active_and_valid_plugins')
+    Functions\expect('get_option')
         ->once()
         ->andReturn([
             '/wp/plugins/buddypress/plugin.php',
@@ -136,110 +96,279 @@ test('Updates dependencies option', function () {
             '/wp/plugins/my-plugin/plugin.php',
         ]);
 
-    Functions\expect('update_option')
-        ->once()
-        ->with('fastendpoints_dependencies', [
-            'GET' => ['/buddypress' => ['/wp/plugins/buddypress/plugin.php'], '/seo' => ['/wp/plugins/seo/plugin.php'], '/empty' => []],
-            'POST' => ['/my-plugin' => ['/wp/plugins/buddypress/plugin.php', '/wp/plugins/my-plugin/plugin.php']],
+    Functions\expect('path_join')
+        ->andReturnUsing(function ($val1, $val2) {
+            return "$val1/$val2";
+        });
+
+    $dependencies = ['/wp/plugins/buddypress/plugin.php', 'seo', 'unknown'];
+    $generator = Mockery::mock(DependenciesGenerator::class)
+        ->makePartial()
+        ->shouldAllowMockingProtectedMethods()
+        ->shouldReceive('isRunningCli')
+        ->andReturn($isRunningCli)
+        ->getMock();
+    $fullPathDependencies = Helpers::invokeNonPublicClassMethod($generator, 'getDependenciesPluginFullPath', $dependencies, 'GET', '/test');
+    expect($fullPathDependencies)
+        ->toBe([
+            '/wp/plugins/buddypress/plugin.php',
+            '/wp/plugins/seo/plugin.php',
         ]);
+})->with([true, false])->group('generator', 'getDependenciesPluginFullPath');
+
+// updateDependenciesConfig
+
+test('Update dependencies option', function () {
+    $dependencies = [
+        'GET' => ['/buddypress' => ['/wp/plugins/buddypress/plugin.php'], '/seo' => ['/wp/plugins/seo/plugin.php'], '/empty' => []],
+        'POST' => ['/my-plugin' => ['/wp/plugins/buddypress/plugin.php', '/wp/plugins/my-plugin/plugin.php']],
+    ];
 
     $generator = Mockery::mock(DependenciesGenerator::class)
         ->makePartial()
         ->shouldAllowMockingProtectedMethods()
-        ->shouldReceive('getDependenciesFromRouters')
-        ->andReturn([
-            'GET' => ['/buddypress' => ['buddypress'], '/seo' => ['/wp/plugins/seo/plugin.php'], '/empty' => []],
-            'POST' => ['/my-plugin' => ['buddypress', 'my-plugin']],
-        ])
+        ->shouldReceive('getRoutesDependencies')
+        ->andReturn($dependencies)
+        ->getMock()
+        ->shouldReceive('saveConfigFile')
+        ->once()
+        ->with($dependencies)
         ->getMock();
 
-    $generator->updateDependenciesOption();
-})->group('generator', 'updateDependenciesOption');
+    $generator->updateDependenciesConfig();
+})->group('generator', 'updateDependenciesConfig');
 
-test('Updates dependencies option via CLI', function () {
+test('Update dependencies option via CLI', function () {
     Mockery::mock('alias:WP_CLI')
-        ->shouldReceive('debug')
-        ->times(3)
-        ->getMock()
         ->shouldReceive('success')
-        ->with('Successfully updated dependencies for 0 routers');
+        ->with('REST route dependencies updated');
 
-    Functions\expect('WP_CLI\Utils\format_items')
-        ->once();
-
-    Functions\expect('path_join')
-        ->andReturnUsing(function ($val1, $val2) {
-            return "$val1/$val2";
-        });
-
-    Functions\expect('wp_get_active_and_valid_plugins')
-        ->once()
-        ->andReturn([
-            '/wp/plugins/buddypress/plugin.php',
-            '/wp/plugins/seo/plugin.php',
-            '/wp/plugins/my-plugin/plugin.php',
-        ]);
-
-    Functions\expect('update_option')
-        ->once()
-        ->with('fastendpoints_dependencies', [
-            'GET' => ['/buddypress' => ['/wp/plugins/buddypress/plugin.php'], '/seo' => ['seo.php'], '/empty' => []],
-            'POST' => ['/my-plugin' => ['/wp/plugins/buddypress/plugin.php', '/wp/plugins/my-plugin/plugin.php']],
-        ]);
-
+    $dependencies = [
+        'GET' => ['/buddypress' => ['buddypress'], '/seo' => ['seo.php'], '/empty' => []],
+        'POST' => ['/my-plugin' => ['buddypress', 'my-plugin']],
+    ];
     $generator = Mockery::mock(DependenciesGenerator::class)
         ->makePartial()
         ->shouldAllowMockingProtectedMethods()
-        ->shouldReceive('getDependenciesFromRouters')
-        ->andReturn([
-            'GET' => ['/buddypress' => ['buddypress'], '/seo' => ['seo.php'], '/empty' => []],
-            'POST' => ['/my-plugin' => ['buddypress', 'my-plugin']],
-        ])
+        ->shouldReceive('getRoutesDependencies')
+        ->andReturn($dependencies)
+        ->getMock()
+        ->shouldReceive('saveConfigFile')
+        ->once()
+        ->with($dependencies)
         ->getMock()
         ->shouldReceive('isRunningCli')
         ->andReturn(true)
         ->getMock();
 
-    $generator->updateDependenciesOption();
-})->group('generator', 'updateDependenciesOption');
+    $generator->updateDependenciesConfig();
+})->group('generator', 'updateDependenciesConfig');
 
-// getDependenciesFromRouters
+// allRestRoutes
 
-test('Retrieving dependencies from routers', function () {
-    Functions\expect('register_rest_route');
+test('Retrieve all REST routes', function () {
+    $restServerMock = Mockery::mock('alias:WP_REST_Server')
+        ->shouldReceive('get_routes')
+        ->times(3)
+        ->andReturnUsing(function (?string $namespace = null) {
+            if (! $namespace === null) {
+                return [1, 2, 3, 4];
+            }
+
+            return [
+                "/$namespace/depends" => [[
+                    'methods' => ['GET' => true],
+                    'depends' => ['buddypress', 'seo'],
+                    'accept_json' => false,
+                ]],
+                "/$namespace/depends/empty" => [[
+                    'methods' => ['PATCH' => true],
+                    'depends' => [],
+                ]],
+                "/$namespace/no-depends" => [[
+                    'methods' => ['PUT' => true, 'POST' => true, 'DELETE' => false],
+                ]],
+            ];
+        })
+        ->getMock()
+        ->shouldReceive('get_namespaces')
+        ->once()
+        ->andReturn(['test/v1', 'test/v2'])
+        ->getMock();
+
+    Functions\expect('rest_get_server')
+        ->once()
+        ->andReturn($restServerMock);
+
     $generator = new DependenciesGenerator;
-    $firstRouter = new Router('api', 'v1');
-    $firstRouter->get('/first', function () {
-        return true;
-    })->depends(['hey']);
-
-    $subRouter = new Router('posts');
-    $subRouter->get('/posts', function () {
-        return true;
-    })->depends(['full-path.php', 'posts']);
-    $firstRouter->includeRouter($subRouter);
-
-    $secondRouter = new Router('api', 'v2');
-    $secondRouter->post('/second', function () {
-        return true;
-    })->depends(['second']);
-
-    // Trigger endpoint creation
-    $firstRouter->register();
-    $secondRouter->register();
-    $firstRouter->registerEndpoints();
-    $subRouter->registerEndpoints();
-    $secondRouter->registerEndpoints();
-
-    $routers = [$firstRouter, $secondRouter];
-    $dependencies = Helpers::invokeNonPublicClassMethod($generator, 'getDependenciesFromRouters', $routers);
-    expect($dependencies)
-        ->toBeArray()
-        ->toMatchArray([
-            'GET' => [
-                '/api/v1/first' => ['hey'],
-                '/api/v1/posts/posts' => ['full-path.php', 'posts'],
-            ],
-            'POST' => ['/api/v2/second' => ['second']],
+    $allRestRoutes = Helpers::invokeNonPublicClassMethod($generator, 'allRestRoutes');
+    $allRestRoutes = iterator_to_array($allRestRoutes);
+    expect($allRestRoutes)
+        ->toBe([
+            // test/v1
+            ['method' => 'GET', 'route' => '/test/v1/depends', 'depends' => ['buddypress', 'seo']],
+            ['method' => 'PATCH', 'route' => '/test/v1/depends/empty', 'depends' => []],
+            ['method' => 'PUT', 'route' => '/test/v1/no-depends', 'depends' => null],
+            ['method' => 'POST', 'route' => '/test/v1/no-depends', 'depends' => null],
+            // test/v2
+            ['method' => 'GET', 'route' => '/test/v2/depends', 'depends' => ['buddypress', 'seo']],
+            ['method' => 'PATCH', 'route' => '/test/v2/depends/empty', 'depends' => []],
+            ['method' => 'PUT', 'route' => '/test/v2/no-depends', 'depends' => null],
+            ['method' => 'POST', 'route' => '/test/v2/no-depends', 'depends' => null],
         ]);
-})->group('generator', 'getDependenciesFromRouters');
+})->group('generator', 'allRestRoutes');
+
+// getRoutesDependencies
+
+test('Retrieve the dependencies of each REST route', function () {
+    $dependencies = [
+        // test/v1
+        ['method' => 'GET', 'route' => '/test/v1/depends', 'depends' => ['buddypress', 'seo']],
+        ['method' => 'PATCH', 'route' => '/test/v1/depends/empty', 'depends' => []],
+        ['method' => 'PUT', 'route' => '/test/v1/no-depends', 'depends' => null],
+        ['method' => 'POST', 'route' => '/test/v1/no-depends', 'depends' => null],
+        // test/v2
+        ['method' => 'GET', 'route' => '/test/v2/depends', 'depends' => ['buddypress', 'seo']],
+        ['method' => 'PATCH', 'route' => '/test/v2/depends/empty', 'depends' => []],
+        ['method' => 'PUT', 'route' => '/test/v2/no-depends', 'depends' => null],
+        ['method' => 'POST', 'route' => '/test/v2/no-depends', 'depends' => null],
+    ];
+
+    $generator = Mockery::mock(DependenciesGenerator::class)
+        ->makePartial()
+        ->shouldAllowMockingProtectedMethods()
+        ->shouldReceive('allRestRoutes')
+        ->once()
+        ->andReturn($dependencies)
+        ->getMock()
+        ->shouldReceive('getDependenciesPluginFullPath')
+        ->andReturnUsing(function (array $dependencies, string $method, string $route) {
+            return array_map(function ($value) {
+                return "$value.php";
+            }, $dependencies);
+        })
+        ->getMock();
+    $routeDependencies = Helpers::invokeNonPublicClassMethod($generator, 'getRoutesDependencies');
+    expect($routeDependencies)
+        ->toBe([
+            'GET' => [
+                '/test/v1/depends' => ['buddypress.php', 'seo.php'],
+                '/test/v2/depends' => ['buddypress.php', 'seo.php'],
+            ],
+            'PATCH' => [
+                '/test/v1/depends/empty' => [],
+                '/test/v2/depends/empty' => [],
+            ],
+        ]);
+})->group('generator', 'getRoutesDependencies');
+
+test('Invalid REST route dependencies', function (bool $isRunningCli) {
+    Mockery::mock('alias:WP_CLI')
+        ->shouldReceive('warning')
+        ->times($isRunningCli ? 1 : 0)
+        ->with('[GET] /test Invalid dependencies. Expecting either null or an array but boolean given');
+
+    $dependencies = [
+        ['method' => 'GET', 'route' => '/test', 'depends' => false],
+    ];
+    $generator = Mockery::mock(DependenciesGenerator::class)
+        ->makePartial()
+        ->shouldAllowMockingProtectedMethods()
+        ->shouldReceive('allRestRoutes')
+        ->once()
+        ->andReturn($dependencies)
+        ->getMock()
+        ->shouldReceive('isRunningCli')
+        ->andReturn($isRunningCli)
+        ->getMock();
+
+    $routeDependencies = Helpers::invokeNonPublicClassMethod($generator, 'getRoutesDependencies');
+    expect($routeDependencies)
+        ->toBe([]);
+})->with([true, false])->group('generator', 'getRoutesDependencies');
+
+// getProgressBar
+
+test('Retrieve progress bar', function () {
+    Functions\expect('WP_CLI\Utils\make_progress_bar')
+        ->once()
+        ->with('<message>', 5)
+        ->andReturn('<progress-bar>');
+
+    $generator = Mockery::mock(DependenciesGenerator::class)
+        ->makePartial()
+        ->shouldAllowMockingProtectedMethods()
+        ->shouldReceive('isRunningCli')
+        ->andReturn(true)
+        ->getMock();
+
+    $progressBar = Helpers::invokeNonPublicClassMethod($generator, 'getProgressBar', '<message>', 5);
+    expect($progressBar)
+        ->toBe('<progress-bar>');
+})->group('generator', 'getProgressBar');
+
+// saveConfigFile
+
+test('Saves dependencies config', function () {
+    $configFilePath = tempnam('/tmp', 'configs');
+    file_put_contents($configFilePath, '<?php return ["old-dependencies"]');
+
+    $generator = Mockery::mock(DependenciesGenerator::class)
+        ->makePartial()
+        ->shouldAllowMockingProtectedMethods()
+        ->shouldReceive('getConfigFilePath')
+        ->andReturn($configFilePath)
+        ->getMock();
+
+    $dependencies = [
+        'GET' => [
+            '/test/v1/hey' => ['buddypress.php', 'seo.php'],
+        ],
+    ];
+    Helpers::invokeNonPublicClassMethod($generator, 'saveConfigFile', $dependencies);
+    expect(file_exists($configFilePath))->toBeTrue();
+    $routeDependencies = include $configFilePath;
+    @unlink($configFilePath);
+    expect($routeDependencies)->toEqual($dependencies);
+})->group('generator', 'saveConfigFile');
+
+test('Removes dependencies config if no dependencies are defined', function ($filePath) {
+    if (! is_string($filePath)) {
+        $filePath = stream_get_meta_data($filePath)['uri'];
+    }
+    $generator = Mockery::mock(DependenciesGenerator::class)
+        ->makePartial()
+        ->shouldAllowMockingProtectedMethods()
+        ->shouldReceive('getConfigFilePath')
+        ->andReturn($filePath)
+        ->getMock();
+
+    Helpers::invokeNonPublicClassMethod($generator, 'saveConfigFile', []);
+    expect(file_exists($filePath))->toBeFalse();
+})->with([tmpfile(), '/does/not/exist.php'])->group('generator', 'saveConfigFile');
+
+// getConfigFilePath
+
+test('Retrieve config file path', function () {
+    Functions\expect('plugin_dir_path')
+        ->once()
+        ->andReturn('/plugin/src');
+
+    $generator = new DependenciesGenerator;
+    expect($generator->getConfigFilePath())
+        ->toBe('/plugin/src/../config.php');
+})->group('generator', 'getConfigFilePath');
+
+test('Retrieve config file path via constant', function () {
+    define('FASTENDPOINTS_DEPENDS_CONFIG_FILEPATH', '/plugin/config.php');
+
+    $generator = new DependenciesGenerator;
+    expect($generator->getConfigFilePath())
+        ->toBe('/plugin/config.php');
+})->group('generator', 'getConfigFilePath');
+
+test('Retrieve config file path via argument', function () {
+    $autoloader = new DependenciesGenerator('/custom/config.php');
+    expect(Helpers::invokeNonPublicClassMethod($autoloader, 'getConfigFilePath'))
+        ->toBe('/custom/config.php');
+})->group('generator', 'getConfigFilePath');

--- a/tests/Unit/DependsCommandTest.php
+++ b/tests/Unit/DependsCommandTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Holds tests for the DependsAutoloader class.
+ *
+ * @since 1.0.0
+ *
+ * @license MIT
+ */
+
+declare(strict_types=1);
+
+namespace Wp\FastEndpoints\Depends\Tests\Unit;
+
+use Brain\Monkey;
+use Wp\FastEndpoints\Depends\DependenciesGenerator;
+use Wp\FastEndpoints\Depends\DependsCommand;
+
+beforeEach(function () {
+    Monkey\setUp();
+});
+
+afterEach(function () {
+    Monkey\tearDown();
+});
+
+// update
+
+test('Update dependencies sub-command', function () {
+    $generator = \Mockery::mock(DependenciesGenerator::class)
+        ->makePartial()
+        ->shouldReceive('update')
+        ->once()
+        ->getMock();
+    $command = new DependsCommand($generator);
+    $command->depends();
+})->group('command', 'depends');
+
+// _clear
+
+test('Clears dependencies sub-command', function () {
+    \Mockery::mock('alias:WP_CLI')
+        ->shouldReceive('success')
+        ->once()
+        ->with('REST route dependencies cleared');
+
+    $tmpFile = tmpfile();
+    $tmpFilePath = stream_get_meta_data($tmpFile)['uri'];
+    $generator = \Mockery::mock(DependenciesGenerator::class)
+        ->makePartial()
+        ->shouldReceive('getConfigFilePath')
+        ->once()
+        ->andReturn($tmpFilePath)
+        ->getMock();
+    $command = new DependsCommand($generator);
+    $command->_clear();
+
+    expect(file_exists($tmpFilePath))->toBeFalse();
+})->group('command', 'depends-clear');
+
+test('Clears dependencies sub-command when no configs exist', function () {
+    \Mockery::mock('alias:WP_CLI')
+        ->shouldReceive('success')
+        ->once()
+        ->with('REST route dependencies cleared');
+
+    $generator = \Mockery::mock(DependenciesGenerator::class)
+        ->makePartial()
+        ->shouldReceive('getConfigFilePath')
+        ->once()
+        ->andReturn('/doesnt-exist/config.php')
+        ->getMock();
+    $command = new DependsCommand($generator);
+    $command->_clear();
+})->group('command', 'depends-clear');

--- a/tests/Unit/PluginTest.php
+++ b/tests/Unit/PluginTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 namespace Wp\FastEndpoints\Depends\Tests\Unit;
 
 use Brain\Monkey;
+use Wp\FastEndpoints\Depends\DependenciesGenerator;
 use Wp\FastEndpoints\Depends\DependsAutoloader;
-use Wp\FastEndpoints\Depends\FastEndpointDependenciesGenerator;
 
 beforeEach(function () {
     Monkey\setUp();
@@ -35,7 +35,7 @@ test('Registering both autoloader and generator', function () {
     $autoloader = \Mockery::mock(DependsAutoloader::class)
         ->shouldReceive('register')
         ->getMock();
-    $generator = \Mockery::mock(FastEndpointDependenciesGenerator::class)
+    $generator = \Mockery::mock(DependenciesGenerator::class)
         ->shouldReceive('register')
         ->withArgs(function (string $filepath) {
             return file_exists($filepath) && str_ends_with($filepath, 'fastendpoints-depends.php');

--- a/tests/constants.php
+++ b/tests/constants.php
@@ -2,6 +2,9 @@
 
 define('TESTS_DIR', __DIR__);
 define('PLUGIN_ROOT_DIR', dirname(\TESTS_DIR));
+define('SAMPLE_CONFIG_FILEPATH', \TESTS_DIR.'/Data/config.php');
+define('EMPTY_CONFIG_FILEPATH', \TESTS_DIR.'/Data/empty-config.php');
+define('ROUTERS_DIR', \TESTS_DIR.'/Integration/Routers/');
 if (! defined('WP_PLUGIN_DIR')) {
     define('WP_PLUGIN_DIR', '/wp/plugins');
 }


### PR DESCRIPTION
- Add support to WP native endpoints
- Moved dependencies from DB to a file

```php
// Native WP endpoints support

register_rest_route('native/v1', 'custom', [
    'methods' => 'GET',
    'depends' => ['my-plugin'],
    (...)
]);
```